### PR TITLE
Add Dns zone examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
 
 cache:
     directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 [Compare v0.2.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v0.2.0...master)
+### Breaking
+- The public property `type` in the `ApiResource` class has been renamed to `resourceType` in order not to conflict with the DNS record resource, which has a `type` attribute.
+
+### Added
+- Two examples for DNS zones and records.
 
 ## [v0.2.0](https://github.com/exonet/exonet-api-php/releases/tag/v0.2.0) - 2018-07-09
 [Compare v0.1.0 - v0.2.0](https://github.com/exonet/backend/compare/v0.1.0...v0.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to `exonet-api-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v0.2.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v0.2.0...master)
+[Compare v1.0.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v1.0.0...master)
+
+## [v1.0.0](https://github.com/exonet/exonet-api-php/releases/tag/v1.0.0) - 2019-04-29
+[Compare v0.2.0 - v1.0.0](https://github.com/exonet/backend/compare/v0.2.0...v1.0.0)
 ### Breaking
 - The public property `type` in the `ApiResource` class has been renamed to `resourceType` in order not to conflict with the DNS record resource, which has a `type` attribute.
 

--- a/docs/api_responses.md
+++ b/docs/api_responses.md
@@ -10,7 +10,7 @@ is returned. The instance of this class contains the requested resources. Traver
 ```php
 $certificates = $client->resource('certificates')->get();
 
-foreach ($certificates as $certificate) {  
+foreach ($certificates as $certificate) {
     // Each item is an instance of an ApiResource.
     echo $certificate->id."\n";
 }
@@ -18,7 +18,7 @@ foreach ($certificates as $certificate) {
 
 ## The `ApiResource` class
 Each resource returned by the API is transformed to an `ApiResource` instance. This makes it possible to have easy access
-to the attributes, type and ID of the resource. Each of these fields can be accessed as if it is a property on the class:
+to the attributes, resourceType and ID of the resource. Each of these fields can be accessed as if it is a property on the class:
 
 ```php
 $certificate = $client->resource('certificates')->get('VX09kwR3KxNo');
@@ -41,7 +41,7 @@ $domainResource = $certificate->domain()->get();
 ```
 
 If you only want the data of the relation in the `ApiResource` itself, you can get it by using the `raw()` method. This
-will return a (multidimensional) array with the resource type and id:
+will return a (multidimensional) array with the resourceType and ID:
 
 ```php
 $domainRelationData = $certificate->domain()->raw();

--- a/examples/dns_zone_details.php
+++ b/examples/dns_zone_details.php
@@ -1,0 +1,40 @@
+<?php
+
+// Run this script using: php examples/ticket_details.php <YOUR-TOKEN>
+
+require __DIR__.'/../vendor/autoload.php';
+
+$authentication = new Exonet\Api\Auth\PersonalAccessToken($argv[1]);
+
+$exonetApi = new Exonet\Api\Client($authentication);
+
+/*
+ * Get a single dns_zone resource. Because depending on who is authorized, the dns_zone IDs change, all dns_zones are
+ * retrieved with a limit of 1. From this result, the first DNS zone is used. In a real world scenario you would
+ * call something like `$zone = $exonetApi->resource('dns_zones')->get('VX09kwR3KxNo');` to get a single DNS zone
+ * by it's ID.
+ */
+$zones = $exonetApi->resource('dns_zones')->size(1)->get();
+// Show this message when there are no zones.
+if (empty($zones)) {
+    echo 'There are no zones available.';
+    die();
+}
+$zone = $zones[0];
+
+// Output DNS zone details.
+echo sprintf("\nDNS zone:\t%s\n", $zone->name);
+
+// Get the records for this zone.
+$records = $zone->records()->get();
+// Show records.
+foreach ($records as $record) {
+    echo sprintf(
+        "%s  %s   %s   %s\n",
+        $record->type,
+        $record->fqdn,
+        $record->ttl,
+        $record->content,
+    );
+}
+echo "\n";

--- a/examples/dns_zone_details.php
+++ b/examples/dns_zone_details.php
@@ -30,7 +30,7 @@ $records = $zone->records()->get();
 // Show records.
 foreach ($records as $record) {
     echo sprintf(
-        "%s  %s   %s   %s\n",
+        "%s\t%s\t%s\t%s\n",
         $record->type,
         $record->fqdn,
         $record->ttl,

--- a/examples/dns_zone_details.php
+++ b/examples/dns_zone_details.php
@@ -34,7 +34,7 @@ foreach ($records as $record) {
         $record->type,
         $record->fqdn,
         $record->ttl,
-        $record->content,
+        $record->content
     );
 }
 echo "\n";

--- a/examples/dns_zones.php
+++ b/examples/dns_zones.php
@@ -1,0 +1,27 @@
+<?php
+
+// Run this script using: php examples/dns_zones.php <YOUR-TOKEN>
+
+use Exonet\Api\Structures\ApiResourceSet;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$authentication = new Exonet\Api\Auth\PersonalAccessToken($argv[1]);
+
+$exonetApi = new Exonet\Api\Client($authentication);
+
+// Get all DNS zones, limited to 20.
+$zones = $exonetApi->resource('dns_zones')->size(20)->get();
+
+$description = 'DNS zones (max 20):';
+echo sprintf(
+    "\n%s\n%s\n",
+    $description,
+    str_repeat('-', strlen($description))
+);
+
+foreach ($zones as $zone) {
+    echo sprintf("%s - %d records\n", $zone->name, count($zone->records()->raw()));
+}
+
+echo "\n";

--- a/examples/dns_zones.php
+++ b/examples/dns_zones.php
@@ -2,8 +2,6 @@
 
 // Run this script using: php examples/dns_zones.php <YOUR-TOKEN>
 
-use Exonet\Api\Structures\ApiResourceSet;
-
 require __DIR__.'/../vendor/autoload.php';
 
 $authentication = new Exonet\Api\Auth\PersonalAccessToken($argv[1]);

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,7 @@ class Client implements LoggerAwareInterface
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = 'v0.1.0';
+    public const CLIENT_VERSION = 'v1.0.0';
 
     /**
      * @var Client The client instance.

--- a/src/Structures/ApiResource.php
+++ b/src/Structures/ApiResource.php
@@ -15,7 +15,7 @@ class ApiResource implements ArrayAccess
     /**
      * @var string The resource type.
      */
-    public $type;
+    public $resourceType;
 
     /**
      * @var string The resource ID.
@@ -40,8 +40,7 @@ class ApiResource implements ArrayAccess
     public function __construct($contents)
     {
         $data = is_array($contents) ? $contents : json_decode($contents, true)['data'];
-
-        $this->type = $data['type'];
+        $this->resourceType = $data['type'];
         $this->id = $data['id'];
         $this->attributes = $data['attributes'];
         $this->relationships = isset($data['relationships']) ? $this->parseRelations($data['relationships']) : null;
@@ -96,7 +95,7 @@ class ApiResource implements ArrayAccess
     }
 
     /**
-     * Check if the given offset exists as property (for ID or type) or as attribute. Required by the ArrayAccess
+     * Check if the given offset exists as property (for ID or resourceType) or as attribute. Required by the ArrayAccess
      * interface.
      *
      * @param string $offset The offset.
@@ -128,7 +127,7 @@ class ApiResource implements ArrayAccess
      */
     public function offsetSet($offset, $value) : void
     {
-        if ($offset === 'id' || $offset === 'type') {
+        if ($offset === 'id' || $offset === 'resourceType') {
             $this->{$offset} = $value;
 
             return;

--- a/tests/Structures/ApiResourceSetTest.php
+++ b/tests/Structures/ApiResourceSetTest.php
@@ -72,10 +72,11 @@ class ApiResourceSetTest extends TestCase
     public function testArrayAccessMethods()
     {
         $resourceSetClass = new ApiResourceSet(json_encode($this->resourceSetData));
+        $resources = $resourceSetClass->getIterator();
 
         $this->assertSame(
             'world1',
-            reset($resourceSetClass->getIterator())['hello']
+            reset($resources)['hello']
         );
 
         // Test isset with an offset that should not exist.

--- a/tests/Structures/ApiResourceSetTest.php
+++ b/tests/Structures/ApiResourceSetTest.php
@@ -83,7 +83,11 @@ class ApiResourceSetTest extends TestCase
         $this->assertFalse(isset($resourceSetClass[55]));
 
         // Set a new offset.
-        $resourceSetClass[55] = new ApiResource([]);
+        $resourceSetClass[55] = new ApiResource([
+            'id' => 'ABC',
+            'type' => 'some_resource',
+            'attributes' => [],
+        ]);
 
         // Test isset with an offset that should now exist.
         $this->assertTrue(isset($resourceSetClass[55]));

--- a/tests/Structures/ApiResourceTest.php
+++ b/tests/Structures/ApiResourceTest.php
@@ -24,7 +24,7 @@ class ApiResourceTest extends TestCase
     {
         $resourceClass = new ApiResource(self::SIMPLE_RESOURCE);
 
-        $this->assertSame('unitTest', $resourceClass->type);
+        $this->assertSame('unitTest', $resourceClass->resourceType);
         $this->assertSame('testId', $resourceClass->id);
         $this->assertSame('world', $resourceClass->hello);
 
@@ -54,7 +54,7 @@ class ApiResourceTest extends TestCase
     {
         $resourceClass = new ApiResource(self::SIMPLE_RESOURCE);
 
-        $this->assertSame('unitTest', $resourceClass['type']);
+        $this->assertSame('unitTest', $resourceClass['resourceType']);
         $this->assertSame('testId', $resourceClass['id']);
         $this->assertSame('world', $resourceClass['hello']);
 


### PR DESCRIPTION
## Description
#### 🚨Contains breaking change.
Rename class property to not interfere with a commonly used attribute in the API.

**Breaking because:** Using `ApiResource::type` no longer returns the resource type provided by the API. Instead `ApiResource::resourceType` must be used.

Add two examples to get started with DNS in the API.
- dns_zone_details.php - Get a zone and show all records in it.
- dns_zones.php - Show all zones.

## How has this been tested?
`composer test`

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)