### PR TITLE
Extend ValidationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `exonet-api-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.1.1 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.1.1...master)
+[Compare v2.2.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.2.0...master)
+
+## [v2.2.0](https://github.com/exonet/exonet-api-php/releases/tag/v2.2.0) - 2019-11-18
+[Compare v2.1.1 - v2.2.0](https://github.com/exonet/exonet-api-php/compare/v2.1.1...v2.2.0)
+### Changed
+- Extend the `ValidationException` to contain all returned validation errors. See the [docs](./docs/exceptions.md) for more information.
 
 ## [v2.1.1](https://github.com/exonet/exonet-api-php/releases/tag/v2.1.1) - 2019-09-19
 [Compare v2.1.0 - v2.1.1](https://github.com/exonet/exonet-api-php/compare/v2.1.0...v2.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## Unreleased
 [Compare v2.2.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.2.0...master)
 
-## [v2.2.0](https://github.com/exonet/exonet-api-php/releases/tag/v2.2.0) - 2019-11-18
+## [v2.2.0](https://github.com/exonet/exonet-api-php/releases/tag/v2.2.0) - 2019-11-19
 [Compare v2.1.1 - v2.2.0](https://github.com/exonet/exonet-api-php/compare/v2.1.1...v2.2.0)
 ### Changed
 - Extend the `ValidationException` to contain all returned validation errors. See the [docs](./docs/exceptions.md) for more information.

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -12,6 +12,12 @@ exceptions thrown by this package are extending `Exonet\Exceptions\ExonetApiExce
 
 When no sensible exception can be thrown, an `UnknownException` will be thrown.
 
+## Validation exceptions
+In case of a validation exception an exception message is returned indicating the number of failed validation rules.
+You can access all failed validation errors by calling the `$exception->getFailedValidations()` method. This will return
+an multi-dimensional array keyed by field (attribute/relation) name with the corresponding validation errors. Validation 
+errors that are not related to a field are keyed with `generic`.
+
 ---
 
 [&laquo; Using API Responses](api_responses.md) | [Back to the index](index.md)

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -6,4 +6,24 @@ namespace Exonet\Api\Exceptions;
 
 class ValidationException extends ExonetApiException
 {
+    /**
+     * Add a validation error to the variable details.
+     *
+     * @param string|null $field       The name of the field.
+     * @param string      $description The returned error description.
+     */
+    public function setFailedValidation(?string $field, string $description) : void
+    {
+        $this->variables[$field ?? 'generic'][] = $description;
+    }
+
+    /**
+     * Get all failed validations.
+     *
+     * @return array The failed validation details.
+     */
+    public function getFailedValidations() : array
+    {
+        return $this->variables;
+    }
 }

--- a/tests/Exceptions/ResponseExceptionHandlerTest.php
+++ b/tests/Exceptions/ResponseExceptionHandlerTest.php
@@ -56,6 +56,7 @@ class ResponseExceptionHandlerTest extends TestCase
         $exceptionHandler = new ResponseExceptionHandler($response, $client);
 
         $validationTested = false;
+
         try {
             $exceptionHandler->handle();
         } catch (ValidationException $exception) {
@@ -81,6 +82,7 @@ class ResponseExceptionHandlerTest extends TestCase
         $exceptionHandler = new ResponseExceptionHandler($response, $client);
 
         $validationTested = false;
+
         try {
             $exceptionHandler->handle();
         } catch (ValidationException $exception) {


### PR DESCRIPTION
## Description
Extend the `ValidationException` to contain all returned validation errors.

Also tag a new release. See changelog.