### PR TITLE
Validate response for PATCH and DELETE requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `exonet-api-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.3.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.3.0...master)
+[Compare v2.4.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.4.0...master)
+
+## [v2.4.0](https://github.com/exonet/exonet-api-php/releases/tag/v2.4.0) - 2021-01-20
+[Compare v2.3.0 - v2.4.0](https://github.com/exonet/exonet-api-php/compare/v2.3.0...v2.4.0)
+### Changed
+- On `PATCH` and `DELETE` requests the response will be parsed to trigger a possible `ValidationException`.
 
 ## [v2.3.0](https://github.com/exonet/exonet-api-php/releases/tag/v2.3.0) - 2020-08-07
 [Compare v2.2.0 - v2.3.0](https://github.com/exonet/exonet-api-php/compare/v2.2.0...v2.3.0)

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -126,7 +126,9 @@ class Connector
             json_encode($data)
         );
 
-        self::httpClient()->send($request);
+        $response = self::httpClient()->send($request);
+
+        $this->parseResponse($response);
 
         return true;
     }
@@ -151,7 +153,9 @@ class Connector
             json_encode($data)
         );
 
-        self::httpClient()->send($request);
+        $response = self::httpClient()->send($request);
+
+        $this->parseResponse($response);
 
         return true;
     }

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -220,7 +220,7 @@ class ConnectorTest extends TestCase
                 422,
                 [],
                 '{"errors":[{"status":422,"code":"102.10001","title":"validation.generic","detail":"Validation did not pass.","variables":[]}]}'
-            )
+            ),
         ]);
 
         $history = Middleware::history($apiCalls);
@@ -250,7 +250,7 @@ class ConnectorTest extends TestCase
                 422,
                 [],
                 '{"errors":[{"status":422,"code":"102.10001","title":"validation.generic","detail":"Validation did not pass.","variables":[]}]}'
-            )
+            ),
         ]);
 
         $history = Middleware::history($apiCalls);


### PR DESCRIPTION
## Description

The response of `PATCH` and `DELETE` requests will be parsed to trigger a `ValidationException` when the API returned with a `422` status code.

The Changelog has already been updated to release version `2.4.0`.

## Motivation and context
A PATCH request with invalid data would return `true` without making clear the request failed.

## How has this been tested?
[Tests have been added](https://github.com/exonet/exonet-api-php/commit/e2f45f077dae6af731ab1a2424c1c14ace982006)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [ ] I'm creating this PR to the `develop` branch.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

