### PR TITLE
Dont parse response for Delete and patch requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `exonet-api-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.4.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.4.0...master)
+[Compare v2.4.1 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.4.1...master)
+
+## [v2.4.1](https://github.com/exonet/exonet-api-php/releases/tag/v2.4.1) - 2021-01-29
+[Compare v2.4.0 - v2.4.1](https://github.com/exonet/exonet-api-php/compare/v2.4.0...v2.4.1)
+### Fixed
+- Parsing the response of a `DELETE` and `PATCH` requests will only validate the response.
 
 ## [v2.4.0](https://github.com/exonet/exonet-api-php/releases/tag/v2.4.0) - 2021-01-20
 [Compare v2.3.0 - v2.4.0](https://github.com/exonet/exonet-api-php/compare/v2.3.0...v2.4.0)

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ class Client implements LoggerAwareInterface
     /**
      * The version of this package. Used in the user-agent header.
      */
-    public const CLIENT_VERSION = 'v2.3.0';
+    public const CLIENT_VERSION = 'v2.4.1';
 
     /**
      * The API base URL.

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -128,7 +128,7 @@ class Connector
 
         $response = self::httpClient()->send($request);
 
-        $this->parseResponse($response);
+        $this->validateResponse($response);
 
         return true;
     }
@@ -155,7 +155,7 @@ class Connector
 
         $response = self::httpClient()->send($request);
 
-        $this->parseResponse($response);
+        $this->validateResponse($response);
 
         return true;
     }
@@ -174,9 +174,7 @@ class Connector
     {
         $this->apiClient()->log()->debug('Request completed', ['statusCode' => $response->getStatusCode()]);
 
-        if ($response->getStatusCode() >= 300) {
-            (new ResponseExceptionHandler($response))->handle();
-        }
+        $this->validateResponse($response);
 
         $contents = $response->getBody()->getContents();
 
@@ -193,6 +191,18 @@ class Connector
         }
 
         return new ApiResourceIdentifier($decodedContent->data->type, $decodedContent->data->id);
+    }
+
+    /**
+     * Validate a response. Check for validation errors.
+     *
+     * @param PsrResponse $response The call response.
+     */
+    private function validateResponse(PsrResponse $response)
+    {
+        if ($response->getStatusCode() >= 300) {
+            (new ResponseExceptionHandler($response))->handle();
+        }
     }
 
     /**

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -188,7 +188,7 @@ class ConnectorTest extends TestCase
     public function testDelete()
     {
         $apiCalls = [];
-        $mock = new MockHandler([new Response(201, [], json_encode($this->singleResource))]);
+        $mock = new MockHandler([new Response(204)]);
 
         $history = Middleware::history($apiCalls);
         $handler = HandlerStack::create($mock);
@@ -197,9 +197,7 @@ class ConnectorTest extends TestCase
         new Client(new PersonalAccessToken('test-token'));
         $connectorClass = new Connector($handler);
 
-        $payload = ['test' => 'demo'];
-
-        $result = $connectorClass->delete('url', $payload);
+        $result = $connectorClass->delete('url');
 
         $this->assertTrue($result);
         $this->assertCount(1, $apiCalls);


### PR DESCRIPTION
## Description
Parsing the response of a `DELETE` and `PATCH` requests will only validate the response. Because parsing the response data is not always possible.
