### PR TITLE
Dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 .history
+.vscode
 /vendor/
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.history
 /vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
-    - docker pull php:7.1-cli
-    - docker pull php:7.2-cli
     - docker pull php:7.3-cli
     - docker pull php:7.4-cli
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+php:
+  - 7.3
+
 services:
     - docker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## Unreleased
 [Compare v3.0.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v3.0.0...master)
 
-## [v3.0.0](https://github.com/exonet/exonet-api-php/releases/tag/v3.0.0) - 2021-10-18
+## [v3.0.0](https://github.com/exonet/exonet-api-php/releases/tag/v3.0.0) - 2021-10-19
 [Compare v2.4.1 - v3.0.0](https://github.com/exonet/exonet-api-php/compare/v2.4.1...v3.0.0)
 ### Breaking
 - Dependency updates for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to `exonet-api-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.4.1 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v2.4.1...master)
+[Compare v3.0.0 - Unreleased](https://github.com/exonet/exonet-api-php/compare/v3.0.0...master)
+
+## [v3.0.0](https://github.com/exonet/exonet-api-php/releases/tag/v3.0.0) - 2021-10-18
+[Compare v2.4.1 - v3.0.0](https://github.com/exonet/exonet-api-php/compare/v2.4.1...v3.0.0)
+### Breaking
+- Dependency updates for:
+    - `php` from `7.1` to `7.3`
+    - `guzzlehttp/guzzle` from `~6.0` to `~7.3`
+    - `psr/log` from `^1.0` to `^1.1`
+
+### Changed
+- Updated dev dependencies.
 
 ## [v2.4.1](https://github.com/exonet/exonet-api-php/releases/tag/v2.4.1) - 2021-01-29
 [Compare v2.4.0 - v2.4.1](https://github.com/exonet/exonet-api-php/compare/v2.4.0...v2.4.1)

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         }
     ],
     "require": {
-        "php": "~7.1",
-        "guzzlehttp/guzzle": "~6.0",
-        "psr/log": "^1.0",
+        "php": "~7.3",
+        "guzzlehttp/guzzle": "~7.3",
+        "psr/log": "^1.1",
         "ext-json": "*"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7",
-        "symfony/var-dumper": "^4.0"
+        "symfony/var-dumper": "^4.0",
+        "mockery/mockery": "^1.4.2",
+        "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {
         "psr-4": {

--- a/examples/dns_record_post.php
+++ b/examples/dns_record_post.php
@@ -70,7 +70,7 @@ echo sprintf("\nNew DNS record has ID %s", $newRecord->id());
 // Ask user if record should be updated.
 echo sprintf("\n\nDo you want to patch this record? [y/n] ");
 if ('Y' === strtoupper(trim(fgets(STDIN)))) {
-    $newRecord->attribute('content', 'Exonet API PATCH example '.microtime());
+    $newRecord->attribute('content', '"Exonet API PATCH example '.microtime(). '"');
     $newRecord->patch();
     echo "\nDNS record patched:\n";
     echo sprintf(

--- a/examples/dns_record_post.php
+++ b/examples/dns_record_post.php
@@ -70,7 +70,7 @@ echo sprintf("\nNew DNS record has ID %s", $newRecord->id());
 // Ask user if record should be updated.
 echo sprintf("\n\nDo you want to patch this record? [y/n] ");
 if ('Y' === strtoupper(trim(fgets(STDIN)))) {
-    $newRecord->attribute('content', '"Exonet API PATCH example '.microtime(). '"');
+    $newRecord->attribute('content', '"Exonet API PATCH example '.microtime().'"');
     $newRecord->patch();
     echo "\nDNS record patched:\n";
     echo sprintf(

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,13 @@
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
-    backupGlobals="true"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    cacheTokens="false"
-    colors="true"
->
-    <testsuites>
-        <testsuite name="Exonet API">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="true" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Exonet API">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ if [ "$#" -eq 1 ]; then
     run "$SET_PHP_VERSION"
 else
     # Run tests for different PHP 7 versions.
-    for phpversion in {1..4}; do
+    for phpversion in {3..4}; do
         run "7.$phpversion"
         RESULTS="$RESULTS\n"
     done

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -22,7 +22,7 @@ class ConnectorTest extends TestCase
     /*
      * Setup the the resources by using the setup method, because of the object typecasting.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->singleResource = (object) [
             'data' => [

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -3,10 +3,9 @@
 namespace Exonet\Api;
 
 use Exonet\Api\Auth\PersonalAccessToken;
-use Exonet\Api\Exceptions\AuthenticationException;
-use Exonet\Api\Exceptions\ValidationException;
 use Exonet\Api\Structures\ApiResource;
 use Exonet\Api\Structures\ApiResourceSet;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -125,8 +124,8 @@ class ConnectorTest extends TestCase
 
         $handler = HandlerStack::create($mock);
 
-        $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated');
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Unauthorized');
 
         new Client(new PersonalAccessToken('test-token'));
         $connectorClass = new Connector($handler);
@@ -212,6 +211,9 @@ class ConnectorTest extends TestCase
 
     public function testInvalidPatch()
     {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionCode(422);
+
         $apiCalls = [];
         $mock = new MockHandler([
             new Response(
@@ -229,19 +231,14 @@ class ConnectorTest extends TestCase
         $connectorClass = new Connector($handler);
 
         $payload = ['test' => 'demo'];
-
-        try {
-            $connectorClass->patch('url', $payload);
-        } catch (ValidationException $exception) {
-            $validationTested = true;
-            $this->assertSame($exception->getMessage(), 'There is 1 validation error.');
-            $this->assertCount(1, $exception->getFailedValidations());
-            $this->assertSame('Validation did not pass.', $exception->getFailedValidations()['generic'][0]);
-        }
+        $connectorClass->patch('url', $payload);
     }
 
     public function testInvalidDelete()
     {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionCode(422);
+
         $apiCalls = [];
         $mock = new MockHandler([
             new Response(
@@ -259,14 +256,6 @@ class ConnectorTest extends TestCase
         $connectorClass = new Connector($handler);
 
         $payload = ['test' => 'demo'];
-
-        try {
-            $connectorClass->patch('url', $payload);
-        } catch (ValidationException $exception) {
-            $validationTested = true;
-            $this->assertSame($exception->getMessage(), 'There is 1 validation error.');
-            $this->assertCount(1, $exception->getFailedValidations());
-            $this->assertSame('Validation did not pass.', $exception->getFailedValidations()['generic'][0]);
-        }
+        $connectorClass->patch('url', $payload);
     }
 }

--- a/tests/Structures/RelationTest.php
+++ b/tests/Structures/RelationTest.php
@@ -2,30 +2,12 @@
 
 namespace Exonet\Api\Structures;
 
+use Exonet\Api\Exceptions\InvalidRequestException;
 use Exonet\Api\Request;
 use PHPUnit\Framework\TestCase;
 
 class RelationTest extends TestCase
 {
-    public function testConstruct()
-    {
-        $relationClass = new Relation(
-            'something_related',
-            'test_resources',
-            'ABC1'
-        );
-
-        $this->assertAttributeEquals('something_related', 'name', $relationClass);
-        $this->assertAttributeInstanceOf(Request::class, 'request', $relationClass);
-
-        // Test parsing url pattern to url.
-        $this->assertAttributeEquals(
-            '/test_resources/ABC1/something_related',
-            'url',
-            $relationClass
-        );
-    }
-
     public function testCall()
     {
         $relationClass = new Relation('testRelation', 'test_resources', 'ABC1');
@@ -33,5 +15,14 @@ class RelationTest extends TestCase
         $result = $relationClass->filter('test');
 
         $this->assertInstanceOf(Request::class, $result);
+    }
+
+    public function testCallRequestNull()
+    {
+        $this->expectException(InvalidRequestException::class);
+
+        $relationClass = new Relation('testRelation', 'test_resources');
+
+        $relationClass->filter('test');
     }
 }

--- a/tests/Structures/RelationshipTest.php
+++ b/tests/Structures/RelationshipTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class RelationshipTest extends TestCase
 {
-    public function testConstruct()
+    public function testCall()
     {
         $relationshipClass = new Relationship(
             'something_related',
@@ -15,14 +15,8 @@ class RelationshipTest extends TestCase
             'ABC1'
         );
 
-        $this->assertAttributeEquals('something_related', 'name', $relationshipClass);
-        $this->assertAttributeInstanceOf(Request::class, 'request', $relationshipClass);
+        $result = $relationshipClass->filter('test');
 
-        // Test parsing url pattern to url.
-        $this->assertAttributeEquals(
-            '/test_resources/ABC1/relationships/something_related',
-            'url',
-            $relationshipClass
-        );
+        $this->assertInstanceOf(Request::class, $result);
     }
 }

--- a/tests/Structures/RelationshipTest.php
+++ b/tests/Structures/RelationshipTest.php
@@ -62,7 +62,7 @@ class RelationshipTest extends TestCase
             [
                 'something_related',
                 'test_resources',
-                'ABC1'
+                'ABC1',
             ]
         )
         ->makePartial();

--- a/tests/Structures/RelationshipTest.php
+++ b/tests/Structures/RelationshipTest.php
@@ -3,6 +3,7 @@
 namespace Exonet\Api\Structures;
 
 use Exonet\Api\Request;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class RelationshipTest extends TestCase
@@ -18,5 +19,74 @@ class RelationshipTest extends TestCase
         $result = $relationshipClass->filter('test');
 
         $this->assertInstanceOf(Request::class, $result);
+    }
+
+    public function testToJsonNoIdentifier()
+    {
+        $relationshipClass = new Relationship(
+            'something_related',
+            'test_resources',
+            'ABC1'
+        );
+
+        $resultJson = $relationshipClass->toJson();
+
+        $this->assertNull($resultJson);
+    }
+
+
+    public function testToJsonSingleRelation()
+    {
+        $relationshipClass = new Relationship(
+            'something_related',
+            'test_resources',
+            'ABC1'
+        );
+
+        $relationshipClass->setResourceIdentifiers(new ApiResourceIdentifier('related', 'XYZ'));
+
+        $resultJson = $relationshipClass->toJson();
+
+        $this->assertSame(
+            [
+                'type' => 'related',
+                'id' => 'XYZ',
+            ],
+            $resultJson
+        );
+    }
+
+    public function testToJsonMultiRelation()
+    {
+        $relationshipClass = Mockery::mock(
+            Relationship::class.'[getResourceIdentifiers]',
+            [
+                'something_related',
+                'test_resources',
+                'ABC1'
+            ]
+        )
+        ->makePartial();
+
+        $relationshipClass->shouldReceive('getResourceIdentifiers')->andReturn([
+            new ApiResourceIdentifier('related', 'XYZ'),
+            new ApiResourceIdentifier('related', '999'),
+        ]);
+
+        $resultJson = $relationshipClass->toJson();
+
+        $this->assertSame(
+            [
+                [
+                    'type' => 'related',
+                    'id' => 'XYZ',
+                ],
+                [
+                    'type' => 'related',
+                    'id' => '999',
+                ],
+            ],
+            $resultJson
+        );
     }
 }

--- a/tests/Structures/RelationshipTest.php
+++ b/tests/Structures/RelationshipTest.php
@@ -34,13 +34,12 @@ class RelationshipTest extends TestCase
         $this->assertNull($resultJson);
     }
 
-
     public function testToJsonSingleRelation()
     {
         $relationshipClass = new Relationship(
             'something_related',
             'test_resources',
-            'ABC1'
+            'ABC1',
         );
 
         $relationshipClass->setResourceIdentifiers(new ApiResourceIdentifier('related', 'XYZ'));


### PR DESCRIPTION
## Description

### Breaking
- Dependency updates for:
    - `php` from `7.1` to `7.3`
    - `guzzlehttp/guzzle` from `~6.0` to `~7.3`
    - `psr/log` from `^1.0` to `^1.1`

### Changed
- Updated dev dependencies.

## Motivation and context
Keep the repository updated with new standards.

## How has this been tested?
- Affected unit tests are updated.
- Tested on test-api.exonet.nl

## Release
```
## [v3.0.0](https://github.com/exonet/exonet-api-php/releases/tag/v3.0.0) - 2021-10-19
[Compare v2.4.1 - v3.0.0](https://github.com/exonet/exonet-api-php/compare/v2.4.1...v3.0.0)
### Breaking
- Dependency updates for:
    - `php` from `7.1` to `7.3`
    - `guzzlehttp/guzzle` from `~6.0` to `~7.3`
    - `psr/log` from `^1.0` to `^1.1`

### Changed
- Updated dev dependencies.
```