### PR TITLE
Remove php setup CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,6 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v2
 
-      - name: 🛠 Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-
       - name: 📦 Composer install
         uses: php-actions/composer@v6
         with:


### PR DESCRIPTION
## Description
Remove a step in the CI workflow that is not used.

Providing a PHP versions is included in the composer and phpunit step.
