### PR TITLE
Run CI on PHP 8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
           { php: "8.2", phpunit: "11" },
           { php: "8.3", phpunit: "11" },
           { php: "8.4", phpunit: "11" },
+          { php: "8.5", phpunit: "11" },
         ]
 
     steps:


### PR DESCRIPTION
## Description
Run tests on CI on PHP 8.5.

## Motivation and context

According to composer.json the package already supports PHP 8.5 but the tests on CI we never executed on PHP 8.5.

## How has this been tested?
The CI runs pass.

## Checklist:
- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [X] My pull request contains a title that can be used as a release note.
- [x] I have added the appropriate labels to my pull request
- [x] If my change requires a change to the documentation, I have updated it accordingly.
